### PR TITLE
Fix keyboard removal when creating new ad

### DIFF
--- a/announcements.py
+++ b/announcements.py
@@ -38,7 +38,7 @@ async def create_announcement(update: Update, context: ContextTypes.DEFAULT_TYPE
     context.user_data['photos'] = []
     context.user_data['username'] = username
 
-    await update.message.reply_text(START_NEW_AD)
+    await update.message.reply_text(START_NEW_AD, reply_markup=ReplyKeyboardRemove())
     return EDIT_DESCRIPTION
 
 async def ask_photo_action(update: Update, context: ContextTypes.DEFAULT_TYPE):


### PR DESCRIPTION
## Summary
- remove the reply keyboard when user chooses to create a new ad

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68854c1dc5f8832b9b9c44d5bd7c2929