### PR TITLE
Move keyboards to single module

### DIFF
--- a/announcements.py
+++ b/announcements.py
@@ -137,11 +137,7 @@ async def ask_photo_action(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await send_preview(update, context, editing=is_editing)
             return CHOOSING
 
-    keyboard = InlineKeyboardMarkup([
-        [InlineKeyboardButton(ADD_TO_OLD_PHOTOS, callback_data=f'addphotos_{ann_id}')],
-        [InlineKeyboardButton(REPLACE_ALL_PHOTOS, callback_data=f'replacephotos_{ann_id}')],
-        [InlineKeyboardButton(SKIP_ADD_PHOTOS, callback_data=f'cancel_photo_{ann_id}')]
-    ])
+    keyboard = get_photo_action_keyboard(ann_id)
 
     message_text = HAS_PHOTOS
 
@@ -345,10 +341,7 @@ async def send_preview(update: Update, context: ContextTypes.DEFAULT_TYPE, editi
         is_updated=is_updated, message_ids=message_ids, timestamp=timestamp
     )
 
-    keyboard = InlineKeyboardMarkup([
-        [InlineKeyboardButton(EDIT_BUTTON, callback_data=f'edit_{ann_id}')],
-        [InlineKeyboardButton(PUBLISH_BUTTON, callback_data=f'post_{ann_id}')]
-    ])
+    keyboard = get_preview_keyboard(ann_id)
 
     logger.info(f"📩 [send_preview] Кнопки сформированы, callback_data: edit_{ann_id}, post_{ann_id}")
     if photos:
@@ -549,12 +542,7 @@ async def show_user_announcements(update: Update, context: ContextTypes.DEFAULT_
         price = escape_markdown(price, version=2)
         message = f"{ANNOUNCEMENT_LIST_MESSAGE.format(description=description, price=price)}\n\n{status}"
 
-        keyboard = InlineKeyboardMarkup([
-            [
-                InlineKeyboardButton(EDIT_BUTTON, callback_data=f'edit_{ann_id}'),
-                InlineKeyboardButton(DELETE_BUTTON, callback_data=f'delete_{ann_id}')
-            ]
-        ])
+        keyboard = get_edit_delete_keyboard(ann_id)
 
         logger.info(f"📩 [show_user_announcements] Отправка объявления ID: {ann_id} с кнопками: edit_{ann_id}, delete_{ann_id}")
 

--- a/handlers.py
+++ b/handlers.py
@@ -3,6 +3,7 @@ from database import (
     has_user_ads,
 )
 from announcements import *
+from keyboards import get_edit_menu_keyboard
 from texts import (
     ERROR_CANNOT_DETERMINE_ID,
     ERROR_ANNOUNCEMENT_NOT_FOUND_DB,
@@ -185,12 +186,7 @@ async def edit_announcement_handler(update: Update, context: ContextTypes.DEFAUL
 
     logger.info(f"✏️ [edit_announcement_handler] Открыто меню редактирования для объявления ID: {ann_id}")
 
-    keyboard = InlineKeyboardMarkup([
-        [InlineKeyboardButton(EDIT_TEXT_BUTTON, callback_data=f'editdescription_{ann_id}')],
-        [InlineKeyboardButton(EDIT_PRICE_BUTTON, callback_data=f'editprice_{ann_id}')],
-        [InlineKeyboardButton(EDIT_PHOTOS_BUTTON, callback_data=f'editphotos_{ann_id}')],
-        [InlineKeyboardButton(CANCEL_NOTHING_BUTTON, callback_data=f'cancel_{ann_id}')]
-    ])
+    keyboard = get_edit_menu_keyboard(ann_id)
 
     await query.message.reply_text(EDIT_CHOICE_TEXT, reply_markup=keyboard)
 

--- a/keyboards.py
+++ b/keyboards.py
@@ -37,3 +37,56 @@ finish_photo_markup_no_menu = ReplyKeyboardMarkup(
     one_time_keyboard=True,
     resize_keyboard=True
 )
+
+
+def get_subscription_keyboard() -> InlineKeyboardMarkup:
+    """Keyboard with a single button to confirm subscription."""
+    return InlineKeyboardMarkup(
+        [[InlineKeyboardButton(I_SUBSCRIBED_BUTTON, callback_data="check_subscription")]]
+    )
+
+
+def get_photo_action_keyboard(ann_id: int) -> InlineKeyboardMarkup:
+    """Keyboard asking how to handle existing photos."""
+    return InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton(ADD_TO_OLD_PHOTOS, callback_data=f"addphotos_{ann_id}")],
+            [InlineKeyboardButton(REPLACE_ALL_PHOTOS, callback_data=f"replacephotos_{ann_id}")],
+            [InlineKeyboardButton(SKIP_ADD_PHOTOS, callback_data=f"cancel_photo_{ann_id}")],
+        ]
+    )
+
+
+def get_preview_keyboard(ann_id: int) -> InlineKeyboardMarkup:
+    """Keyboard shown on preview with edit and publish buttons."""
+    return InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton(EDIT_BUTTON, callback_data=f"edit_{ann_id}")],
+            [InlineKeyboardButton(PUBLISH_BUTTON, callback_data=f"post_{ann_id}")],
+        ]
+    )
+
+
+def get_edit_delete_keyboard(ann_id: int) -> InlineKeyboardMarkup:
+    """Keyboard with edit and delete buttons for user's ads list."""
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(EDIT_BUTTON, callback_data=f"edit_{ann_id}"),
+                InlineKeyboardButton(DELETE_BUTTON, callback_data=f"delete_{ann_id}"),
+            ]
+        ]
+    )
+
+
+def get_edit_menu_keyboard(ann_id: int) -> InlineKeyboardMarkup:
+    """Keyboard for the edit announcement menu."""
+    return InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton(EDIT_TEXT_BUTTON, callback_data=f"editdescription_{ann_id}")],
+            [InlineKeyboardButton(EDIT_PRICE_BUTTON, callback_data=f"editprice_{ann_id}")],
+            [InlineKeyboardButton(EDIT_PHOTOS_BUTTON, callback_data=f"editphotos_{ann_id}")],
+            [InlineKeyboardButton(CANCEL_NOTHING_BUTTON, callback_data=f"cancel_{ann_id}")],
+        ]
+    )
+

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,6 @@
 import aiosqlite
 from telegram.ext import ContextTypes
-from telegram import InlineKeyboardMarkup, InlineKeyboardButton, Update
+from telegram import Update
 from telegram.helpers import escape_markdown
 from telegram.constants import ParseMode
 from config import PRIVATE_CHANNEL_ID, INVITE_LINK, DB_PATH
@@ -10,7 +10,11 @@ from datetime import datetime
 import pytz
 
 from database import has_user_ads
-from keyboards import markup, add_advertisement_keyboard
+from keyboards import (
+    markup,
+    add_advertisement_keyboard,
+    get_subscription_keyboard,
+)
 from texts import (
     CHOOSE_ACTION_NEW,
     SUBSCRIPTION_PROMPT,
@@ -59,9 +63,7 @@ async def show_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 async def check_subscription_message():
     text = SUBSCRIPTION_PROMPT
-    keyboard = InlineKeyboardMarkup([
-        [InlineKeyboardButton(I_SUBSCRIBED_BUTTON, callback_data='check_subscription')]
-    ])
+    keyboard = get_subscription_keyboard()
     return text, keyboard
 
 def get_serbia_time():


### PR DESCRIPTION
## Summary
- centralize all keyboard creation in `keyboards.py`
- use helpers from `keyboards` in utils, announcements and handlers

## Testing
- `python -m py_compile keyboards.py utils.py announcements.py handlers.py`

------
https://chatgpt.com/codex/tasks/task_e_688b30140354832ba95893e1e58ca9a3